### PR TITLE
Make clippy happy

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,14 +2,10 @@ mod ui;
 mod utils;
 
 use std::error::Error;
-use std::io;
 // Function to extract the YouTube video ID from a URL
-use utils::export_piper_link;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     ui::run_gui().await;
-    let youtube_url = String::new();
-
 
     Ok(())
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,6 +1,5 @@
 use eframe::egui;
 use egui::{Vec2, FontId, FontFamily, TextStyle};
-use std::process::{Child};
 use crate::utils::export_piper_link;
 
 pub(crate) async fn run_gui(){
@@ -12,13 +11,13 @@ pub(crate) async fn run_gui(){
         icon_data: None,
         initial_window_pos: None,
         initial_window_size: Option::from(
-            Vec2::new(500 as f32, 150.0)
+            Vec2::new(500_f32, 150.0)
         ),
         min_window_size: Option::from(
-            Vec2::new(500 as f32, 150.0)
+            Vec2::new(500_f32, 150.0)
         ),
         max_window_size: Option::from(
-            Vec2::new(500 as f32, 150.0)
+            Vec2::new(500_f32, 150.0)
         ),
         resizable: false,
         transparent: false,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,14 +2,10 @@ use regex::Regex;
 
 pub fn extract_video_id(url: &str) -> Option<String> {
     let re = Regex::new(r"(?i)(?:youtube\.com/watch\?v=|youtu\.be/)([^\s&]+)").unwrap();
-    if let Some(captures) = re.captures(url) {
-        Some(captures[1].to_string())
-    } else {
-        None
-    }
+    re.captures(url).map(|captures| captures[1].to_string())
 }
 pub fn export_piper_link(youtube_url:&str)->Option<String>{
-    if let Some(video_id) = extract_video_id(&youtube_url) {
+    if let Some(video_id) = extract_video_id(youtube_url) {
         // Construct the piped.link
         let piper_link = format!("https://piped.video/v/{}", video_id);
         return Some(piper_link)


### PR DESCRIPTION
Nothing fancy about this PR:
- Remove unused imports/variables
- Remove unnecessary integer literal castings
- Fix a needless-borrow warning
- Avoid manual implementation of `Option::map` 